### PR TITLE
test: keep Playwright specs out of the vitest run

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig, configDefaults } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
 
@@ -37,5 +37,9 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
+    // e2e/ holds Playwright specs. vitest picks them up by default and they fail with
+    // "Playwright Test did not expect test() to be called here"; they run via
+    // `playwright test` instead.
+    exclude: [...configDefaults.exclude, 'e2e/**'],
   },
 })


### PR DESCRIPTION
Targets `wip/paint-office-20260727` because `e2e/` only exists there.

`vitest` globs `e2e/` by default, so `e2e/npgen.spec.ts` gets collected into the unit test run and fails:

```
Error: Playwright Test did not expect test() to be called here.
 Test Files  1 failed | 50 passed (51)
```

Those specs are meant for `playwright test`, not vitest. Excluding the directory makes `npm run test:run` green again.

```
before: 1 failed | 50 passed (51)
after:  51 passed (51),  936 tests passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bqwpRqgf5qBdfBFB4thvy
